### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Folgende Module beinhaltet das WPLUX Symcon Repository:
 - __Luxtronik__ ([Dokumentation](WPLUX))  
 
-Dieses Modul ermöglicht, Daten der Luxtronic von verschiedener Wärmepumpen-Hersteller abzufragen.
+Dieses Modul ermöglicht, Daten der Luxtronik von verschiedener Wärmepumpen-Hersteller abzufragen.
 Dazu muss sichergestellt werden, dass der Port 8888 (ältere Lux) oder 8889 (neuere Lux) nicht durch die Firewall blockiert ist.
 Dieses Modul funktioniert nur mit Java-Abfrage, ab einem gewissen FW-Stand findet die Abfrage über Websocket statt.
-Die Bedeutung den Typ der Varaibalen sind hier zu finden: https://loxwiki.atlassian.net/wiki/spaces/LOX/pages/1533935933/Java+Webinterface
+Die Bedeutung den Typ der Variablen sind hier zu finden: https://loxwiki.atlassian.net/wiki/spaces/LOX/pages/1533935933/Java+Webinterface


### PR DESCRIPTION
## Summary
- update Luxtronik spelling in README
- fix a typo

## Testing
- `pytest -q`
- `npm test` *(fails: Could not find package.json)*
- `make test` *(fails: No rule to make target 'test')*
- `cargo test` *(fails: could not find Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_684ec0dbe718832694052ae9926d9397