### PR TITLE
Fix comment typo

### DIFF
--- a/WPLUX/variable_profile.php
+++ b/WPLUX/variable_profile.php
@@ -1,6 +1,6 @@
 <?php
 
-// Benötigte Variabelprofile erstellen
+// Benötigte Variablenprofile erstellen
 if (!IPS_VariableProfileExists("WPLUX.Imp")) {
     IPS_CreateVariableProfile("WPLUX.Imp", 1); //1 für Integer
     IPS_SetVariableProfileValues("WPLUX.Imp", 0, 0, 1); //Min, Max, Schritt


### PR DESCRIPTION
## Summary
- fix variable profile comment in `variable_profile.php`

## Testing
- `php -l WPLUX/variable_profile.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec11747688326ab79eac754702e9b